### PR TITLE
ensure native_vector is set when seeding a connection

### DIFF
--- a/langchain_iris/vectorstores.py
+++ b/langchain_iris/vectorstores.py
@@ -95,7 +95,15 @@ class IRISVector(VectorStore):
         self.logger = logger or logging.getLogger(__name__)
         self.override_relevance_score_fn = relevance_score_fn
         self.engine_args = engine_args or {}
-        self._conn = connection if connection else self.connect()
+        if connection:
+            self._conn = connection 
+            try:
+                if connection.dialect.supports_vectors:
+                    self.native_vector = True
+            except:  # noqa
+                pass
+        else: 
+            self._conn = self.connect()
 
         self.__post_init__()
 


### PR DESCRIPTION
When providing a connection directly to the `IRISVector()` constructor, rather than the URL to create one, we're not verifying if the database we're connecting to supports the native vector datatype, as that check is only performed in `connect()`.

The change in this PR is trivially fixing this inside `IRISVector()` because I'm not familiar with other uses of the connection, but either moving the check to a separate `on_connect()` method or changing the `native_vectors` property to dynamically check the connection rather than copy that state may be preferable long term.