### PR TITLE
TDYAR - updated tests and demo notebook to use LangChain version 0.3

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -2,9 +2,20 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
    "source": [
     "%%capture\n",
     "%pip install langchain-iris"
@@ -12,9 +23,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
    "source": [
     "%%capture\n",
     "%pip install testcontainers-iris \\\n",
@@ -26,23 +48,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain.docstore.document import Document\n",
-    "from langchain.document_loaders import TextLoader\n",
-    "from langchain.text_splitter import CharacterTextSplitter\n",
-    "from langchain.embeddings.openai import OpenAIEmbeddings\n",
-    "from langchain.embeddings import HuggingFaceEmbeddings\n",
-    "from langchain.embeddings.fastembed import FastEmbedEmbeddings\n",
+    "from langchain_core.documents import Document\n",
+    "from langchain_community.document_loaders import TextLoader\n",
+    "from langchain_text_splitters import CharacterTextSplitter\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
+    "from langchain_community.embeddings import SentenceTransformerEmbeddings\n",
+    "from langchain_community.embeddings import FastEmbedEmbeddings\n",
     "\n",
     "from langchain_iris import IRISVector\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,24 +90,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!docker pull intersystemsdc/iris-community:2024.1-preview"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Pulling image intersystemsdc/iris-community:2024.1-preview\n",
-      "Container started: 3b28b0550316\n",
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "latest: Pulling from intersystemsdc/iris-community\n",
+      "Digest: sha256:0463f16334b8e4c28a043210aa4e0efe2c1b37a6d92f286203b088a0548aaa8a\n",
+      "Status: Image is up to date for intersystemsdc/iris-community:latest\n",
+      "docker.io/intersystemsdc/iris-community:latest\n",
+      "\u001b[1m\n",
+      "What's next:\u001b[0m\n",
+      "    View a summary of image vulnerabilities and recommendations → \u001b[36mdocker scout quickview intersystemsdc/iris-community:latest\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "!docker pull intersystemsdc/iris-community:latest\n",
+    "# !docker pull intersystemsdc/iris-community-arm64:latest\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Pulling image containers.intersystems.com/intersystems/iris-community-arm64:latest-cd\n",
+      "Container started: 2ea54be8fa0d\n",
       "Waiting to be ready...\n",
       "Waiting to be ready...\n"
      ]
@@ -94,8 +141,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Started iris://demo:demo@localhost:61711/demo\n",
-      "Portal:  http://localhost:61712/csp/sys/UtilHome.csp\n"
+      "Started iris://demo:demo@localhost:58630/demo\n",
+      "Portal:  http://localhost:58631/csp/sys/UtilHome.csp\n"
      ]
     }
    ],
@@ -108,9 +155,12 @@
     "# license_key = os.path.abspath(os.path.expanduser(\"~/iris.key\"))\n",
     "# image = 'containers.intersystems.com/intersystems/iris:2023.3'\n",
     "\n",
-    "# Community Edition\n",
+    "# Community Edition - can be used without a license key\n",
+    "# Use \"latest-preview\" tag for the latest preview version of IRIS Community Edition or\n",
+    "# use \"latest-cd\" to get the latest release version\n",
     "license_key = None\n",
-    "image = 'intersystemsdc/iris-community:2024.1-preview'\n",
+    "image = 'containers.intersystems.com/intersystems/iris-community-arm64:latest-cd'\n",
+    "# image = 'containers.intersystems.com/intersystems/iris:latest-cd'\n",
     "\n",
     "container = IRISContainer(image, username=\"demo\", password=\"demo\", namespace=\"demo\", license_key=license_key)\n",
     "container.with_exposed_ports(1972, 52773)\n",
@@ -125,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -159,7 +209,7 @@
      "output_type": "stream",
      "text": [
       "--------------------------------------------------------------------------------\n",
-      "Score:  0.184773936635373\n",
+      "Score:  0.339997330447091\n",
       "Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \n",
       "\n",
       "Tonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \n",
@@ -169,21 +219,43 @@
       "And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.\n",
       "--------------------------------------------------------------------------------\n",
       "--------------------------------------------------------------------------------\n",
-      "Score:  0.217491455113555\n",
-      "A former top litigator in private practice. A former federal public defender. And from a family of public school educators and police officers. A consensus builder. Since she’s been nominated, she’s received a broad range of support—from the Fraternal Order of Police to former judges appointed by Democrats and Republicans. \n",
+      "Score:  0.397079994006845\n",
+      "And my report is this: the State of the Union is strong—because you, the American people, are strong. \n",
       "\n",
-      "And if we are to advance liberty and justice, we need to secure the Border and fix the immigration system. \n",
+      "We are stronger today than we were a year ago. \n",
       "\n",
-      "We can do both. At our border, we’ve installed new technology like cutting-edge scanners to better detect drug smuggling.  \n",
+      "And we will be stronger a year from now than we are today. \n",
       "\n",
-      "We’ve set up joint patrols with Mexico and Guatemala to catch more human traffickers.  \n",
+      "Now is our moment to meet and overcome the challenges of our time. \n",
       "\n",
-      "We’re putting in place dedicated immigration judges so families fleeing persecution and violence can have their cases heard faster. \n",
+      "And we will, as one people. \n",
       "\n",
-      "We’re securing commitments and supporting partners in South and Central America to host more refugees and secure their own borders.\n",
+      "One America. \n",
+      "\n",
+      "The United States of America. \n",
+      "\n",
+      "May God bless you all. May God protect our troops.\n",
       "--------------------------------------------------------------------------------\n",
       "--------------------------------------------------------------------------------\n",
-      "Score:  0.226851860116283\n",
+      "Score:  0.431181845130686\n",
+      "As Frances Haugen, who is here with us tonight, has shown, we must hold social media platforms accountable for the national experiment they’re conducting on our children for profit. \n",
+      "\n",
+      "It’s time to strengthen privacy protections, ban targeted advertising to children, demand tech companies stop collecting personal data on our children. \n",
+      "\n",
+      "And let’s get all Americans the mental health services they need. More people they can turn to for help, and full parity between physical and mental health care. \n",
+      "\n",
+      "Third, support our veterans. \n",
+      "\n",
+      "Veterans are the best of us. \n",
+      "\n",
+      "I’ve always believed that we have a sacred obligation to equip all those we send to war and care for them and their families when they come home. \n",
+      "\n",
+      "My administration is providing assistance with job training and housing, and now helping lower-income veterans get VA care debt-free.  \n",
+      "\n",
+      "Our troops in Iraq and Afghanistan faced many dangers.\n",
+      "--------------------------------------------------------------------------------\n",
+      "--------------------------------------------------------------------------------\n",
+      "Score:  0.436187286458812\n",
       "And for our LGBTQ+ Americans, let’s finally get the bipartisan Equality Act to my desk. The onslaught of state laws targeting transgender Americans and their families is wrong. \n",
       "\n",
       "As I said last year, especially to our younger transgender Americans, I will always have your back as your President, so you can be yourself and reach your God-given potential. \n",
@@ -195,24 +267,6 @@
       "So tonight I’m offering a Unity Agenda for the Nation. Four big things we can do together.  \n",
       "\n",
       "First, beat the opioid epidemic.\n",
-      "--------------------------------------------------------------------------------\n",
-      "--------------------------------------------------------------------------------\n",
-      "Score:  0.227250762767285\n",
-      "Tonight, I’m announcing a crackdown on these companies overcharging American businesses and consumers. \n",
-      "\n",
-      "And as Wall Street firms take over more nursing homes, quality in those homes has gone down and costs have gone up.  \n",
-      "\n",
-      "That ends on my watch. \n",
-      "\n",
-      "Medicare is going to set higher standards for nursing homes and make sure your loved ones get the care they deserve and expect. \n",
-      "\n",
-      "We’ll also cut costs and keep the economy going strong by giving workers a fair shot, provide more training and apprenticeships, hire them based on their skills not degrees. \n",
-      "\n",
-      "Let’s pass the Paycheck Fairness Act and paid leave.  \n",
-      "\n",
-      "Raise the minimum wage to $15 an hour and extend the Child Tax Credit, so no one has to raise a family in poverty. \n",
-      "\n",
-      "Let’s increase Pell Grants and increase our historic support of HBCUs, and invest in what Jill—our First Lady who teaches full-time—calls America’s best-kept secret: community colleges.\n",
       "--------------------------------------------------------------------------------\n"
      ]
     }
@@ -227,16 +281,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Document(page_content='foo'), 0.0)"
+       "(Document(metadata={}, page_content='foo'), 0.0)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -249,21 +303,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(Document(page_content='foo'), 0.0),\n",
-       " (Document(page_content='foo'), 0.0),\n",
-       " (Document(page_content='A former top litigator in private practice. A former federal public defender. And from a family of public school educators and police officers. A consensus builder. Since she’s been nominated, she’s received a broad range of support—from the Fraternal Order of Police to former judges appointed by Democrats and Republicans. \\n\\nAnd if we are to advance liberty and justice, we need to secure the Border and fix the immigration system. \\n\\nWe can do both. At our border, we’ve installed new technology like cutting-edge scanners to better detect drug smuggling.  \\n\\nWe’ve set up joint patrols with Mexico and Guatemala to catch more human traffickers.  \\n\\nWe’re putting in place dedicated immigration judges so families fleeing persecution and violence can have their cases heard faster. \\n\\nWe’re securing commitments and supporting partners in South and Central America to host more refugees and secure their own borders.', metadata={'source': 'state_of_the_union.txt'}),\n",
-       "  0.241218341760677),\n",
-       " (Document(page_content='And let’s pass the PRO Act when a majority of workers want to form a union—they shouldn’t be stopped.  \\n\\nWhen we invest in our workers, when we build the economy from the bottom up and the middle out together, we can do something we haven’t done in a long time: build a better America. \\n\\nFor more than two years, COVID-19 has impacted every decision in our lives and the life of the nation. \\n\\nAnd I know you’re tired, frustrated, and exhausted. \\n\\nBut I also know this. \\n\\nBecause of the progress we’ve made, because of your resilience and the tools we have, tonight I can say  \\nwe are moving forward safely, back to more normal routines.  \\n\\nWe’ve reached a new moment in the fight against COVID-19, with severe cases down to a level not seen since last July.  \\n\\nJust a few days ago, the Centers for Disease Control and Prevention—the CDC—issued new mask guidelines. \\n\\nUnder these new guidelines, most Americans in most of the country can now be mask free.', metadata={'source': 'state_of_the_union.txt'}),\n",
-       "  0.241445435754669)]"
+       "[(Document(metadata={}, page_content='foo'), 0.0),\n",
+       " (Document(metadata={'source': 'state_of_the_union.txt'}, page_content='And my report is this: the State of the Union is strong—because you, the American people, are strong. \\n\\nWe are stronger today than we were a year ago. \\n\\nAnd we will be stronger a year from now than we are today. \\n\\nNow is our moment to meet and overcome the challenges of our time. \\n\\nAnd we will, as one people. \\n\\nOne America. \\n\\nThe United States of America. \\n\\nMay God bless you all. May God protect our troops.'),\n",
+       "  0.467777216615),\n",
+       " (Document(metadata={'source': 'state_of_the_union.txt'}, page_content='Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans.  \\n\\nLast year COVID-19 kept us apart. This year we are finally together again. \\n\\nTonight, we meet as Democrats Republicans and Independents. But most importantly as Americans. \\n\\nWith a duty to one another to the American people to the Constitution. \\n\\nAnd with an unwavering resolve that freedom will always triumph over tyranny. \\n\\nSix days ago, Russia’s Vladimir Putin sought to shake the foundations of the free world thinking he could make it bend to his menacing ways. But he badly miscalculated. \\n\\nHe thought he could roll into Ukraine and the world would roll over. Instead he met a wall of strength he never imagined. \\n\\nHe met the Ukrainian people. \\n\\nFrom President Zelenskyy to every Ukrainian, their fearlessness, their courage, their determination, inspires the world.'),\n",
+       "  0.481452962114986),\n",
+       " (Document(metadata={'source': 'state_of_the_union.txt'}, page_content='Tonight. I call on the Senate to: Pass the Freedom to Vote Act. Pass the John Lewis Voting Rights Act. And while you’re at it, pass the Disclose Act so Americans can know who is funding our elections. \\n\\nTonight, I’d like to honor someone who has dedicated his life to serve this country: Justice Stephen Breyer—an Army veteran, Constitutional scholar, and retiring Justice of the United States Supreme Court. Justice Breyer, thank you for your service. \\n\\nOne of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court. \\n\\nAnd I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketanji Brown Jackson. One of our nation’s top legal minds, who will continue Justice Breyer’s legacy of excellence.'),\n",
+       "  0.489462614762948)]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,14 +329,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tags=['IRISVector'] vectorstore=<langchain_iris.vectorstores.IRISVector object at 0x13faf9b90>\n"
+      "tags=['IRISVector'] vectorstore=<langchain_iris.vectorstores.IRISVector object at 0x16be58e20> search_kwargs={}\n"
      ]
     }
    ],
@@ -292,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +357,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "lc_iris",
    "language": "python",
    "name": "python3"
   },
@@ -316,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.10.0"
   }
  },
  "nbformat": 4,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3"
 services:
   iris:
-    # image: intersystemsdc/iris-community:2023.3-zpm
-    image: caretdev/iris-community:2024.1-vecdb
+    image: containers.intersystems.com/intersystems/iris-community:latest-preview
     ports:
       - 6172:1972
       - 6173:52773

--- a/tests/test_vectorstores.py
+++ b/tests/test_vectorstores.py
@@ -5,7 +5,7 @@ import string
 
 import pytest
 
-from langchain.docstore.document import Document
+from langchain_core.documents import Document
 from sqlalchemy.orm import Session
 
 from langchain_iris import IRISVector
@@ -13,11 +13,11 @@ from langchain_community.embeddings import DeterministicFakeEmbedding
 
 
 class FakeEmbeddings(DeterministicFakeEmbedding):
-    size = 200
+    size: int = 200
 
 
 class FakeEmbeddingsWithAdaDimension(FakeEmbeddings):
-    size = 1536
+    size: int = 1536
     """Fake embeddings functionality for testing."""
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
@@ -258,7 +258,7 @@ def test_irisvector_retriever_search_threshold(
         search_type="similarity_score_threshold",
         search_kwargs={"k": 3, "score_threshold": 0.999},
     )
-    output = retriever.get_relevant_documents("summer")
+    output = retriever.invoke("summer")
     assert output == [
         Document(page_content="foo", metadata={"page": "0"}),
         Document(page_content="bar", metadata={"page": "1"}),
@@ -286,5 +286,5 @@ def test_irisvector_retriever_search_threshold_custom_normalization_fn(
         search_type="similarity_score_threshold",
         search_kwargs={"k": 3, "score_threshold": 0.5},
     )
-    output = retriever.get_relevant_documents("foo")
+    output = retriever.invoke("foo")
     assert output == []


### PR DESCRIPTION
I made the bare minimum of changes to use the 0.3 langchain version, but also updated the docker images since the latest versions have native vector support.